### PR TITLE
Added check for externalMedia

### DIFF
--- a/asyncari/model.py
+++ b/asyncari/model.py
@@ -271,7 +271,8 @@ class BaseObject(object):
             :return: First class object mapped from HTTP response.
             """
             # Add id to param list
-            kwargs.update(self.id_generator.get_params(self.json))
+            if item != 'externalMedia':
+                kwargs.update(self.id_generator.get_params(self.json))
             log.debug("Issuing command %s %s", item, kwargs)
             oper_ = oper
             resp = await oper_(**kwargs)


### PR DESCRIPTION
[externalMedia](https://docs.asterisk.org/Development/Reference-Information/Asterisk-Framework-and-API-Examples/External-Media-and-ARI/) needs a new channel ID as it is a separate channel. The DefaultObjectIdGenerator just returns the existing channel id, which causes Asterisk to crash and refuse the call.

This "works on my machine", but it's probably not great.

The implementation just skips the update, but it can be the start to a better implementation.